### PR TITLE
Improve crawler robustness

### DIFF
--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import aiohttp
 from bs4 import BeautifulSoup
 from readability import Document
 
 
-async def _fetch(session: aiohttp.ClientSession, url: str) -> str:
-    async with session.get(url) as resp:
-        html = await resp.text()
+SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(3)
+
+
+async def _fetch(session: aiohttp.ClientSession, url: str) -> Optional[str]:
+    async with SEMAPHORE:
+        try:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                resp.raise_for_status()
+                html = await resp.text()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            print(f"Warning: failed to fetch {url}: {exc}")
+            return None
     doc = Document(html)
     content = doc.summary()
     text = BeautifulSoup(content, "lxml").get_text(separator="\n")
@@ -24,7 +33,7 @@ async def run(urls: List[str]) -> Dict[str, str]:
         texts = await asyncio.gather(*tasks, return_exceptions=True)
     results = {}
     for url, text in zip(urls, texts):
-        if isinstance(text, Exception):
+        if text is None or isinstance(text, Exception):
             continue
         results[url] = text
     return results


### PR DESCRIPTION
## Summary
- limit concurrent fetches with a global semaphore
- add timeout and error handling in `_fetch`
- skip None results in `run`

## Testing
- `python -m py_compile scripts/crawl.py`

------
https://chatgpt.com/codex/tasks/task_e_68608637748c8329afeab7e4b3452c1f