### PR TITLE
Add pytest and initial tests

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,11 @@ app = FastAPI()
 DB = VectorDB()
 
 
+@app.get("/")
+async def health() -> dict:
+    return {"status": "ok"}
+
+
 class IngestRequest(BaseModel):
     query: str
     num_results: int = 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ uvicorn[standard]
 readability-lxml
 aiohttp
 python-dotenv
+pytest
+pytest-asyncio
+httpx

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+def test_health_check():
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -1,0 +1,8 @@
+import pytest
+from rag.chunk import chunk_text
+
+
+def test_chunk_text_split():
+    text = "one two three four five"
+    chunks = chunk_text(text, max_tokens=2)
+    assert chunks == ["one two", "three four", "five"]


### PR DESCRIPTION
## Summary
- enable FastAPI health check
- add pytest configuration and asynchronous dependencies
- create simple tests for chunking and API health

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6860873694248329aca2dd4aaf997a00