### PR TITLE
Add ingest_companies utility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ uvicorn[standard]
 readability-lxml
 aiohttp
 python-dotenv
+httpx
+pandas
+openpyxl

--- a/scripts/ingest_companies.py
+++ b/scripts/ingest_companies.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import pandas as pd
+import httpx
+
+
+async def ingest_one(client: httpx.AsyncClient, name: str) -> None:
+    try:
+        resp = await client.post("/ingest?num_results=5", json={"query": name})
+        resp.raise_for_status()
+        data: dict[str, Any] = resp.json()
+        count = data.get("ingested", 0)
+        print(f"[OK ] {name} \u2192 ingested {count}")
+    except Exception as exc:
+        print(f"[NG ] {name} \u2192 {exc}")
+
+
+async def main() -> None:
+    df = pd.read_excel("data_j.xls", sheet_name="Sheet1", dtype=str)
+    cols = ["コード", "銘柄名", "市場・商品区分", "33業種区分"]
+    df = df[cols]
+    df = df.dropna(how="all")
+
+    api_url = os.getenv("API_URL", "http://localhost:8000")
+    async with httpx.AsyncClient(base_url=api_url) as client:
+        for name in df["銘柄名"].dropna():
+            await ingest_one(client, name)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `scripts/ingest_companies.py` to ingest RAG data from Excel
- include dependencies for pandas, httpx and openpyxl

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608921916083299f21dc58f4ebb92e