### PR TITLE
Add simple web UI with FastAPI and HTMX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aiohttp
 beautifulsoup4
 chromadb
 fastapi
+jinja2
 google-api-python-client
 google-generativeai>=0.3.2
 httpx

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <title>HistoriCulture</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico">
+    <script src="https://unpkg.com/htmx.org"></script>
+</head>
+<body>
+    <h1>Histriculture</h1>
+    <form hx-post="/ask" hx-target="#response-area" hx-swap="innerHTML">
+        <input type="text" name="question">
+        <button type="submit">送信</button>
+    </form>
+    <div id="response-area"></div>
+</body>
+</html>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -5,6 +5,13 @@ from api.main import app
 
 def test_health_check():
     client = TestClient(app)
-    response = client.get("/")
+    response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_index_returns_html():
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]


### PR DESCRIPTION
## Summary
- add `jinja2` dependency
- serve HTML template and move health check
- stream answers directly from `/ask`
- create basic HTMX UI
- update tests for new endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68609a17c0488329835fbe28c3eace0c