### PR TITLE
Add async ingestion pipeline and entrypoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Deploy to Railway
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RUN_MODE: web
         run: |
           # --serviceフラグでデプロイ対象のサービス名を指定する
           # "HistoriCulture"の部分を、あなたの実際のサービス名に置き換えてください

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,16 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+# Add entrypoint script
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]
+# Default to web mode
+ENV RUN_MODE=web
 
 # Railway provides the PORT env var.
 EXPOSE ${PORT:-8000}
 
 #CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
-# --- ★★★★★ ここが最後の修正点 ★★★★★ ---
 # python -u で非バッファモードで実行し、print文がリアルタイムでログに出るようにする
 CMD ["python", "-u", "-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ uvicorn api.main:app --reload
 ## データの取り込み
 
 `/ingest` エンドポイントに対してクエリを POST すると、指定のキーワードで検索した Web ページをクロールし、埋め込み後に ChromaDB に保存します。保存したデータは `/ask` エンドポイントでの回答生成に利用されます。`api/worker.py` を直接実行すると、あらかじめ用意されたトピックを順番に取り込みます。
+
+## Running Worker Locally or in Railway
+
+- To start FastAPI server (default):
+  ```bash
+  RUN_MODE=web uvicorn api.main:app --reload
+  # or with Docker
+  docker run -e RUN_MODE=web histoculture
+  ```
+
+- To run ingestion worker one-off:
+  ```bash
+  RUN_MODE=worker python api/worker.py
+  # or Railway CLI:
+  railway run RUN_MODE=worker docker run histoculture
+  ```

--- a/api/worker.py
+++ b/api/worker.py
@@ -1,6 +1,7 @@
 # api/worker.py
 from __future__ import annotations
 
+import asyncio
 from api.main import ingest_pipeline
 
 DEFAULT_TOPICS = [
@@ -9,14 +10,19 @@ DEFAULT_TOPICS = [
     "ガンディーの生涯",
 ]
 
+
 def main() -> None:
     print("--- Starting direct ingestion worker ---")
+    total = 0
     for topic in DEFAULT_TOPICS:
         try:
-            ingest_pipeline(query=topic, num_results=10)
+            count = asyncio.run(ingest_pipeline(query=topic, num_results=10))
+            total += count
+            print(f"[OK ] {topic} → ingested {count} chunks")
         except Exception as e:
-            print(f"ERROR during ingestion for '{topic}': {e}")
-    print("--- Finished direct ingestion worker ---")
+            print(f"[NG ] {topic} → {e}")
+    print(f"--- Finished ingestion: total {total} chunks ---")
+
 
 if __name__ == "__main__":
     main()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+# RUN_MODE: "web" (default) or "worker"
+if [ "$RUN_MODE" = "worker" ]; then
+  echo "[entrypoint] Running ingestion worker..."
+  exec python api/worker.py
+else
+  echo "[entrypoint] Starting FastAPI server..."
+  exec uvicorn api.main:app --host 0.0.0.0 --port 8000 --timeout-keep-alive 60
+fi


### PR DESCRIPTION
## Summary
- create configurable entrypoint script for web/worker modes
- add RUN_MODE setup in Dockerfile
- document RUN_MODE usage in README
- implement async `ingest_pipeline` with error handling and logging
- use the new pipeline from `/ingest` endpoint and worker
- add `/health` endpoint for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68849b3c55f88329b80e28fbad5f664f