### PR TITLE
Refactor ingestion pipeline

### DIFF
--- a/api/worker.py
+++ b/api/worker.py
@@ -16,7 +16,7 @@ def main() -> None:
     total = 0
     for topic in DEFAULT_TOPICS:
         try:
-            count = asyncio.run(ingest_pipeline(query=topic, num_results=10))
+            count = asyncio.run(ingest_pipeline(topic, num_results=10))
             total += count
             print(f"[OK ] {topic} → ingested {count} chunks")
         except Exception as e:


### PR DESCRIPTION
## Summary
- centralize ingestion logic in `ingest_pipeline`
- call this new pipeline from the API endpoint and worker
- configure logging at module load time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68849eb436888329a53d67044a057482