### PR TITLE
Add embedding and fix ingest loop

### DIFF
--- a/rag/embed.py
+++ b/rag/embed.py
@@ -32,3 +32,11 @@ class GeminiEmbedding:
             task_type="RETRIEVAL_QUERY"
         )
         return result["embedding"]
+
+
+embedder = GeminiEmbedding()
+
+
+def embed_texts(texts: List[str]) -> List[List[float]]:
+    """Convenience wrapper to embed multiple texts."""
+    return embedder.embed_documents(texts)


### PR DESCRIPTION
## Summary
- add embed_texts import and embedding step in ingest pipeline
- ensure VectorDB.add receives embedding
- provide helper `embed_texts`
- simplify ingest pipeline docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6884c32e44408329adbe8b656042ff45