### PR TITLE
Implement text-embedding query

### DIFF
--- a/rag/generate.py
+++ b/rag/generate.py
@@ -7,7 +7,6 @@ from typing import AsyncGenerator
 import google.generativeai as genai
 
 from .vectordb import VectorDB
-from .embed import GeminiEmbedding  # このimportが今度こそ成功します
 
 # Configure Gemini
 genai.configure(api_key=os.getenv("GOOGLE_API_KEY"))
@@ -25,12 +24,8 @@ async def answer(question: str, db: VectorDB, n_results: int = 5) -> AsyncGenera
     """
     Generates a streaming answer.
     """
-    # 1. Create an instance of our embedding class
-    embedder = GeminiEmbedding()
-    # 2. Use it to create a vector from the user's question
-    question_embedding = embedder.embed_query(text=question)
-    # 3. Query the DB with the generated vector
-    matches = db.query(query_embedding=question_embedding, n_results=n_results)
+    # Query the DB directly with the question text
+    matches = db.query(query_text=question, n_results=n_results)
 
     if not matches:
         yield "申し訳ありませんが、関連する情報がデータベースに見つかりませんでした。"

--- a/rag/vectordb.py
+++ b/rag/vectordb.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import chromadb
 from typing import List, Dict, Any
+from rag.embed import embed_texts
 
 DB_PATH = "./db"
 COLLECTION_NAME = "histriculture"
@@ -35,11 +36,13 @@ class VectorDB:
 
     def query(
         self,
-        query_embedding: List[float],
+        query_text: str,
         n_results: int = 5
     ) -> List[Dict[str, Any]]:
+        # Compute embedding for the text query
+        embedding = embed_texts([query_text])[0]
         res = self.collection.query(
-            query_embeddings=[query_embedding],
+            query_embeddings=[embedding],
             n_results=n_results
         )
         docs = res.get("documents", [[]])[0]


### PR DESCRIPTION
## Summary
- embed queries inside `VectorDB.query`
- simplify `answer` to call `db.query` directly with text

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6884d77b59088329b5dc83dcaf9a5668